### PR TITLE
Rename package from `http2-secure-reverse-proxy-nodejs` to `@mangs/http2-secure-reverse-proxy-nodejs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2
+
+- Rename package from `http2-secure-reverse-proxy-nodejs` to `@mangs/http2-secure-reverse-proxy-nodejs`
+- Add NPM package link to readme
+
 ## 1.0.1
 
 - Fix publish workflow

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# http2-secure-reverse-proxy-nodejs
+# NPM Package `@mangs/http2-secure-reverse-proxy-nodejs` [![Package Version](https://img.shields.io/npm/v/@mangs/http2-secure-reverse-proxy-nodejs)](https://www.npmjs.com/package/@mangs/http2-secure-reverse-proxy-nodejs)
 
 HTTP2-based reverse proxy server using Node.js and TLS (no dependencies)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "http2-secure-reverse-proxy-nodejs",
-  "version": "1.0.1",
+  "name": "@mangs/http2-secure-reverse-proxy-nodejs",
+  "version": "1.0.2",
   "author": "Eric Goldstein",
   "description": "HTTP2-based reverse proxy server using Node.js and TLS (no dependencies)",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `1.0.2`
- Rename package from `http2-secure-reverse-proxy-nodejs` to `@mangs/http2-secure-reverse-proxy-nodejs`
- Add NPM package link to readme